### PR TITLE
Fixed issue31

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -343,6 +343,10 @@ the current context."
 	     ((looking-at ".*=[ \t]*$")
 	      (setq cur-indent (+ (current-indentation) tab-width)))
 
+       ;; if the previous line ends in |, indent one level
+       ((looking-at ".*|[ \t]*$")
+	      (setq cur-indent (+ (current-indentation) tab-width)))
+
 	     ((ponylang--looking-at-indent-start)
 	      (setq cur-indent (+ (current-indentation) tab-width)))
 


### PR DESCRIPTION
Fixed issue: if the previous line ends in |, indent one level.
https://github.com/ponylang/ponylang-mode/issues/31#issue-411114803