### PR TITLE
Differentiate docstrings from strings

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -95,9 +95,9 @@ by parse-partial-sexp, and should return a face. "
   (if (nth 3 state)
       (save-excursion
         (goto-char (nth 8 state))
-        (while (and (progn (beginning-of-line) (bobp))
+        (while (and (progn (previous-line) (beginning-of-line) (not (bobp)))
                     (or (looking-at "^$") (looking-at "^[ \t]*$")))
-          (previous-line))
+          nil)
         (if (looking-at "^[ \t]*\\(class\\|actor\\|primitive\\|struct\\|trait\\|interface\\|fun\\|be\\)")
             'font-lock-doc-face
           'font-lock-string-face))
@@ -283,8 +283,6 @@ by parse-partial-sexp, and should return a face. "
 
     ;; keywords
     (,ponylang-keywords-regexp . font-lock-keyword-face)
-
-    ("\'\\\\?.\'" . font-lock-string-face)
 
     ;; note: order above matters. “ponylang-keywords-regexp” goes last because
     ;; otherwise the keyword “state” in the function “state_entry”

--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -89,6 +89,20 @@
 
     table))
 
+(defun ponylang-mode-syntactic-face-function (state)
+  "The function is called with one argument, the parse state at point returned 
+by parse-partial-sexp, and should return a face. "
+  (if (nth 3 state)
+      (save-excursion
+        (goto-char (nth 8 state))
+        (while (and (progn (beginning-of-line) (bobp))
+                    (or (looking-at "^$") (looking-at "^[ \t]*$")))
+          (previous-line))
+        (if (looking-at "^[ \t]*\\(class\\|actor\\|primitive\\|struct\\|trait\\|interface\\|fun\\|be\\)")
+            'font-lock-doc-face
+          'font-lock-string-face))
+    'font-lock-comment-face))
+
 (defvar ponylang-mode-map
   (let ((map (make-keymap)))
     (define-key map "\C-j" 'newline-and-indent)
@@ -495,7 +509,11 @@ the current context."
   :syntax-table ponylang-mode-syntax-table
   (setq-local comment-start "// ")
   (setq-local comment-start-skip "//+")
-  (setq-local font-lock-defaults '(ponylang-font-lock-keywords))
+  (setq-local font-lock-defaults
+              '(ponylang-font-lock-keywords
+                nil nil nil nil
+                (font-lock-syntactic-face-function
+                 . ponylang-mode-syntactic-face-function)))
   (setq-local indent-line-function 'ponylang-indent-line)
   (setq-local syntax-propertize-function ponylang-syntax-propertize-function)
   (setq-local indent-tabs-mode nil)


### PR DESCRIPTION
This PR solves the `issue 6` opened by @jeremyheiler , now the sorghum rendering of strings and documents will be handled separately.
https://github.com/ponylang/ponylang-mode/issues/6#issue-142099529
See:
![ponylang-mode-issue-6](https://user-images.githubusercontent.com/1702133/82409379-2dad5300-9aa0-11ea-821d-323660e5392e.png)
