### PR TITLE
Fixed issue 28-31 and relieve issue 9

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -282,7 +282,14 @@
 (defun ponylang--looking-at-indent-start ()
   "Determines if the current position is 'looking at' a keyword
   that starts new indentation."
-  (-any? (lambda (k) (looking-at (concat  "^[ \t]*" k))) ponylang-indent-start-keywords))
+  (-any? (lambda (k) (looking-at (concat  "^[ \t]*" k)))
+         ponylang-indent-start-keywords))
+
+(defun ponylang--looking-at-indent-declare ()
+  "Determines if the current position is 'looking at' a keyword
+  that declaration new indentation."
+  (-any? (lambda (k) (looking-at (concat  ".*" k ".*[,|][ \t]*$")))
+         ponylang-declaration-keywords))
 
 (defun ponylang-syntactic-indent-line ()
   "Indent current line as pony code based on language syntax and
@@ -339,10 +346,17 @@ the current context."
 	    (setq keep-looking nil)
 	    (forward-line -1)
 	    (cond
-	     ;; if the previous line ends in =, indent one level
-	     ((looking-at ".*=[ \t]*$")
+	     ;; if the previous line ends in = or =>, indent one level
+	     ((looking-at ".*\\(=>\\|=\\)[ \t]*$")
 	      (setq cur-indent (+ (current-indentation) tab-width)))
 
+       ;; if the previous line ends in )
+       ((looking-at ".*)[ \t]*$")
+        (setq cur-indent (max 0 (- (current-indentation) tab-width))))
+
+       ((ponylang--looking-at-indent-declare)
+	      (setq cur-indent (+ (current-indentation) tab-width)))
+       
 	     ((ponylang--looking-at-indent-start)
 	      (setq cur-indent (+ (current-indentation) tab-width)))
 

--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -282,7 +282,7 @@
 (defun ponylang--looking-at-indent-start ()
   "Determines if the current position is 'looking at' a keyword
   that starts new indentation."
-  (-any? (lambda (k) (looking-at (concat  "^[ \t]*" k)))
+  (-any? (lambda (k) (looking-at (concat  "^[ \t]*" k "[ \t]")))
          ponylang-indent-start-keywords))
 
 (defun ponylang--looking-at-indent-declare ()
@@ -350,13 +350,13 @@ the current context."
 	     ((looking-at ".*\\(=>\\|=\\)[ \t]*$")
 	      (setq cur-indent (+ (current-indentation) tab-width)))
 
-       ;; if the previous line ends in )
-       ((looking-at ".*)[ \t]*$")
-        (setq cur-indent (max 0 (- (current-indentation) tab-width))))
+	     ;; if the previous line ends in )
+	     ((looking-at ".*)[ \t]*$")
+	      (setq cur-indent (max 0 (- (current-indentation) tab-width))))
 
-       ((ponylang--looking-at-indent-declare)
+	     ((ponylang--looking-at-indent-declare)
 	      (setq cur-indent (+ (current-indentation) tab-width)))
-       
+
 	     ((ponylang--looking-at-indent-start)
 	      (setq cur-indent (+ (current-indentation) tab-width)))
 


### PR DESCRIPTION
https://github.com/ponylang/ponylang-mode/issues/31#issue-411114803
https://github.com/ponylang/ponylang-mode/issues/30#issue-411010055
https://github.com/ponylang/ponylang-mode/issues/29#issue-410917091
https://github.com/ponylang/ponylang-mode/issues/28#issue-408618735

I found that `issues 28-31` are similar problems, I solved them together.

This PR can alleviate `issue 9`: https://github.com/ponylang/ponylang-mode/issues/9#issue-142955018
````pony
class iso _TestSenderMessageConstruction is UnitTest
  """
  Test that our sender is correctly taking data and returning a properly
  formatted message that we can send on its merry way
  """
````
The above code will indent normally. But,
````pony
class iso _TestSenderMessageConstruction is UnitTest
  """
  Test that our sender is correctly taking data and returning a properly
  for matted message that we can send on its merry way
    """
````
place your cursor after the last " and hit return, it will indent the """ incorrectly.
Note，The second line of the comment, if the word at the beginning of the last line of the string is the same as the keyword defined in ponylang-indent-start-keywords, it will cause indentation problems.I will fix it in a separate PR.
