### PR TITLE
Fix this and reference capabilities highlight color

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -186,7 +186,7 @@
   "Pony language operators functions.")
 
 (defconst ponylang-constants
-  '("false" "true" "None")
+  '("false" "true" "this" "None")
   "Common constants.")
 
 ;; create the regex string for each class of keywords
@@ -235,7 +235,7 @@
     (,ponylang-functions-regexp . font-lock-constant-face)
 
     ;; capabilities
-    (,ponylang-capabilities-regexp . font-lock-preprocessor-face)
+    (,ponylang-capabilities-regexp . font-lock-builtin-face)
 
     ;; capability constraints
     ("#\\(?:read\\|send\\|share\\|any\\|alias\\)" . 'font-lock-builtin-face)


### PR DESCRIPTION
- Lock `this` font as a constant
- `Reference capabilities` uses builtin font face
See:
![highlight](https://user-images.githubusercontent.com/1702133/82430965-a02e2b00-9ac0-11ea-828e-35b7d0edd145.png)
