### PR TITLE
Better type and constant highlighting

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -273,14 +273,17 @@ by parse-partial-sexp, and should return a face. "
      1
      'font-lock-function-name-face)
 
-    ;; actor, class, and type references
+    ;; type references: first filter
+    (".*:\\s +\\($?[A-Z_][A-Za-z0-9_]*\\)" 1 'font-lock-type-face)
+    
+    ;; constants
+    (,ponylang-constant-regexp . font-lock-constant-face)
+    
+    ;; type references: second filter
     ("\\(\s\\|[\[]\\|[\(]\\)\\($?_?[A-Z][A-Za-z0-9_]*\\)" 2 'font-lock-type-face)
 
     ;; ffi
     ("@[A-Za-z_][A-Z-a-z0-9_]+" . 'font-lock-builtin-face)
-
-    ;; constants
-    (,ponylang-constant-regexp . font-lock-constant-face)
 
     ;;(,ponylang-event-regexp . font-lock-builtin-face)
     ;;(,ponylang-functions-regexp . font-lock-function-name-face)


### PR DESCRIPTION
https://github.com/ponylang/ponylang-mode/issues/7#issue-142104179
@jeremyheiler  reported a problem of None highlighting in `issue 7`, but  i see that issue7 is a deep problem: 
When the constant name is capitalized, there will be a highlight conflict. 
I have fixed this problem in this PR.
See：
![issue-7](https://user-images.githubusercontent.com/1702133/82543980-f665a180-9b86-11ea-98a2-870a9592ef9e.png)
