### PR TITLE
Font lock for variable definitions

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -258,6 +258,11 @@ by parse-partial-sexp, and should return a face. "
     ;; capability constraints
     ("#\\(?:read\\|send\\|share\\|any\\|alias\\)" . 'font-lock-builtin-face)
 
+    ;; Variables definitions
+    (".*\\(object\\|let\\|var\\|embed\\|for\\)\\s +\\([^( \t\n,:]+\\)"
+     2
+     'font-lock-variable-name-face)
+
     ;; actor and class definitions
     ("\\(?:actor\\|class\\)\s+\\(?:\\(?:box\\|iso\\|ref\\|tag\\|trn\\|val\\)\s+\\)?\\($?[A-Z_][A-Za-z0-9_]*\\)"
      1


### PR DESCRIPTION
New feature: font lock for variable definitions
See:
![PR-49](https://user-images.githubusercontent.com/1702133/82546180-4db94100-9b8a-11ea-90ad-dc942626da90.png)
