### PR TITLE
Improved type highlighting

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -279,7 +279,7 @@ by parse-partial-sexp, and should return a face. "
      'font-lock-function-name-face)
 
     ;; type references: first filter
-    (".*:\\s +\\($?[A-Z_][A-Za-z0-9_]*\\)" 1 'font-lock-type-face)
+    (":?[ \t]?\\($?[A-Z_][A-Za-z0-9_]*\\)" 1 'font-lock-type-face)
     
     ;; constants
     (,ponylang-constant-regexp . font-lock-constant-face)

--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -279,7 +279,7 @@ by parse-partial-sexp, and should return a face. "
      'font-lock-function-name-face)
 
     ;; type references: first filter
-    (":?[ \t]?\\($?[A-Z_][A-Za-z0-9_]*\\)" 1 'font-lock-type-face)
+    (":$?[ \t]?\\($?[A-Z_][A-Za-z0-9_]*\\)" 1 'font-lock-type-face)
     
     ;; constants
     (,ponylang-constant-regexp . font-lock-constant-face)


### PR DESCRIPTION
Multiple types defined in one line can be correctly identified, and optional spaces are allowed.