### PR TITLE
Added method references highlighting

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -294,6 +294,9 @@ by parse-partial-sexp, and should return a face. "
     ;; ffi
     ("@[A-Za-z_][A-Z-a-z0-9_]+" . 'font-lock-builtin-face)
 
+    ;; method references
+    ("$?.?\\($?[a-z_][a-z0-9_]+\\)(+" 1 'font-lock-function-name-face)
+
     ;;(,ponylang-event-regexp . font-lock-builtin-face)
     ;;(,ponylang-functions-regexp . font-lock-function-name-face)
 


### PR DESCRIPTION
In the past version, when you refer to a method, the method name is white, which is very unfriendly. This PR added the method reference highlighting feature to ponylang-mode.
See:
![method-ref](https://user-images.githubusercontent.com/1702133/82723462-bc6cda80-9d01-11ea-9012-c36a340293f6.png)
