### PR TITLE
Improve method reference highlighting

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -295,7 +295,7 @@ by parse-partial-sexp, and should return a face. "
     ("@[A-Za-z_][A-Z-a-z0-9_]+" . 'font-lock-builtin-face)
 
     ;; method references
-    ("$?.?\\($?[a-z_][a-z0-9_]+\\)(+" 1 'font-lock-function-name-face)
+    ("$?.?\\($?[a-z_][a-z0-9_]+\\)$?[ \t]?(+" 1 'font-lock-negation-char-face)
 
     ;;(,ponylang-event-regexp . font-lock-builtin-face)
     ;;(,ponylang-functions-regexp . font-lock-function-name-face)


### PR DESCRIPTION
Improve method reference highlighting，make the space between the method name and the brackets optional