### PR TITLE
Delimiter grouping

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -250,8 +250,11 @@ by parse-partial-sexp, and should return a face. "
     ;; declaration
     (,ponylang-declaration-keywords-regexp . font-lock-preprocessor-face)
 
-    ;; delimiter: separate
-    ("[^+-/*//%<>=!]\\([=:/.;,]\\)[^+-/*//%<>=!]" 1 'font-lock-comment-delimiter-face)
+    ;; delimiter: . , ; separate
+    ("\\([.,;]\\)" 1 'font-lock-comment-delimiter-face)
+
+    ;; delimiter: = : separate 
+    ("[^+-/*//%~^!=<>]\\([=:]\\)[^+-/*//%~^!=<>]" 1 'font-lock-comment-delimiter-face)
 
     ;; delimiter: modifier
     ("\\(=>\\|\\.>\\|:>\\||\\)" 1 'font-lock-keyword-face)


### PR DESCRIPTION
Delimiter grouping:
- group1: `.`, `,` and `;`
- group2: `:` and `=`

After grouping, highlighting can be more accurate