### PR TITLE
Fixed docstring highlighting

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -101,7 +101,9 @@ by parse-partial-sexp, and should return a face. "
         (while (and (progn (previous-line) (beginning-of-line) (not (bobp)))
                     (or (looking-at "^$") (looking-at "^[ \t]*$")))
           nil)
-        (if (looking-at "^[ \t]*\\(class\\|actor\\|primitive\\|struct\\|trait\\|interface\\|fun\\|be\\|new\\)")
+        (if (or (looking-at ".*=>$?[ \t]?$")
+                (looking-at
+                 "^[ \t]*\\(class\\|actor\\|primitive\\|struct\\|trait\\|interface\\|type\\|fun\\|be\\|new\\)"))
             'font-lock-doc-face
           'font-lock-string-face))
     'font-lock-comment-face))


### PR DESCRIPTION
This PR solves the problem of long hidden docstring highlighting.
Look at the comparison:
- Before repair:
![Screenshot from 2020-05-27 17-05-27](https://user-images.githubusercontent.com/1702133/83000391-e04f5980-a03c-11ea-9037-7d5dd71ed80b.png)
- After repair:
![Screenshot from 2020-05-27 17-04-45](https://user-images.githubusercontent.com/1702133/83000408-e5aca400-a03c-11ea-8c5f-cf47a2f31be2.png)