### PR TITLE
Fixed generic references highlighting

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -300,7 +300,7 @@ by parse-partial-sexp, and should return a face. "
     (,ponylang-constant-regexp . font-lock-constant-face)
 
     ;; type references: second filter
-    ("\\(\s\\|[\[]\\|[\(]\\)\\($?_?[A-Z][A-Za-z0-9_]*\\)" 2 'font-lock-type-face)
+    ("\\(\s\\|->\\|[\[]\\|[\(]\\)\\($?_?[A-Z][A-Za-z0-9_]*\\)" 2 'font-lock-type-face)
 
     ;; tuple references
     ("[.]$?[ \t]?\\($?_[1-9]$?[0-9]?*\\)" 1 'font-lock-variable-name-face)


### PR DESCRIPTION
````pony
fun clone(): HashAnySet[this->A!]^ =>
    """
    Create a clone. The element type may be different due to aliasing and
    viewpoint adaptation.
    """
    let r = HashAnySet[this->A!](_f_hash, size())

    for value in values() do
      r.set(value)
    end
    r
````
In the above example, `this->A!` is not highlighted correctly, this PR fixed this problem.