### PR TITLE
Fixed numeric highlighting

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -315,7 +315,7 @@ by parse-partial-sexp, and should return a face. "
     ("\\([a-z_]$?[a-z0-9_]?+\\)$?[ \t]?(+" 1 'font-lock-function-name-face)
 
     ;; numeric literals
-    ("[^A-Za-z]\\([0-9]+\\)+" 1 'font-lock-constant-face)
+    ("\\([0-9][A-Za-z0-9]*\\)" 1 'font-lock-constant-face)
 
     ;;(,ponylang-event-regexp . font-lock-builtin-face)
     ;;(,ponylang-functions-regexp . font-lock-function-name-face)


### PR DESCRIPTION
The current version can only recognize decimal digits, This PR fixed highlighting of hexadecimal, octal, and decimal.