### PR TITLE
Changed imenu grouping

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -668,12 +668,15 @@ value is 0 then no banner is displayed."
   "Major mode for editing Pony files."
   :syntax-table ponylang-mode-syntax-table
   (setq-local imenu-generic-expression
-              '(("TODO" "^[ \t]*TODO[ \t]*\\(.*\\)$" 1)
-                ("fun" "^[ \t]*\\(fun\\|be\\new\\)[ \t]*\\(.*\\)=>" 2)
+              '(("TODO" ".*TODO:[ \t]*\\(.*\\)$" 1)
+                ;; ("fun" "^[ \t]*\\(new\\|be\\|fun\\)[ \t]*\\(.*\\)=>" 2)
+                ("fun" "^[ \t]*fun[ \t]*\\(.*\\)$" 1)
+                ("be" "^[ \t]*be[ \t]*\\(.*\\)$" 1)
+                ("new" "^[ \t]*new[ \t]*\\(.*\\)$" 1)
                 ("type" "^[ \t]*type[ \t]*\\(.*\\)$" 1)
                 ("interface" "^[ \t]*interface[ \t]*\\(.*\\)$" 1)
-                ("struct" "^[ \t]*struct[ \t]*\\(.*\\)$" 1)
                 ("trait" "^[ \t]*trait[ \t]*\\(.*\\)$" 1)
+                ("struct" "^[ \t]*struct[ \t]*\\(.*\\)$" 1)
                 ("primitive" "^[ \t]*primitive[ \t]*\\(.*\\)$" 1)
                 ("actor" "^[ \t]*actor[ \t]*\\(.*\\)$" 1)
                 ("class" "^[ \t]*class[ \t]*\\(.*\\)$" 1)


### PR DESCRIPTION
1.Split the method into `new` `fun` and `be`, when there are many methods it's useful.
2.Improve the display order of `struct` grouping
3.TODO group ignore `:`