### PR TITLE
Fixed methods nesting highlighting

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -318,6 +318,9 @@ by parse-partial-sexp, and should return a face. "
     ;; type references: second filter
     ("\\(\s\\|->\\|[\[]\\|[\(]\\)\\($?_?[A-Z][A-Za-z0-9_]*\\)" 2 'font-lock-type-face)
 
+    ;; method references
+    ("\\([a-z_]$?[a-z0-9_]?+\\)$?[ \t]?(+" 1 'font-lock-function-name-face)
+
     ;; parameter
     ("\\(?:(\\|,\\)\\([a-z_][a-z0-9_']*\\)\\([^ \t\r\n,:)]*\\)" 1
        'font-lock-variable-name-face)
@@ -329,9 +332,6 @@ by parse-partial-sexp, and should return a face. "
 
     ;; ffi
     ("@[A-Za-z_][A-Z-a-z0-9_]+" . 'font-lock-builtin-face)
-
-    ;; method references
-    ("\\([a-z_]$?[a-z0-9_]?+\\)$?[ \t]?(+" 1 'font-lock-function-name-face)
 
     ;;(,ponylang-event-regexp . font-lock-builtin-face)
     ;;(,ponylang-functions-regexp . font-lock-function-name-face)


### PR DESCRIPTION
When the method is nested in multiple layers, there will be problems when the method name is highlighted,See:
![Screenshot from 2020-06-15 16-14-09](https://user-images.githubusercontent.com/1702133/84635317-a4196580-af25-11ea-926c-01a6409fc784.png)
This PR fixed it:
![Screenshot from 2020-06-15 16-29-28](https://user-images.githubusercontent.com/1702133/84635369-b4c9db80-af25-11ea-8ff1-4983bae5993f.png)
