### PR TITLE
Fixed match indent to be consistent with Style Guide

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -178,7 +178,6 @@ by parse-partial-sexp, and should return a face. "
     "else"                              ;
     "for" "fun"                         ;
     "if" "ifdef" "interface"            ;
-    "match"                             ;
     "new"                               ;
     "primitive"                         ;
     "recover" "ref" "repeat"            ;
@@ -398,10 +397,12 @@ the current context."
            (setq cur-indent tab-width))
           ((looking-at "^[[:space:]]*new\\([[:space:]].*\\)?$")
            (setq cur-indent tab-width))
-          ((looking-at "^[ \t]*\\(end\\|else\\|elseif\\|do\\|then\\|until\\)$")
+          ((looking-at "^[ \t]*\\(|\\|end\\|else\\|elseif\\|do\\|then\\|until\\)[ \t]*.*$")
            (progn (save-excursion ;;
                     (forward-line -1)
-                    (setq cur-indent (current-indentation)))))
+                    (if (looking-at "^[ \t]*\\(|\\).*$")
+                        (setq cur-indent (current-indentation))
+                      (setq cur-indent (max 0 (- (current-indentation) tab-width)))))))
           (t                            ;
            (save-excursion              ;
              (let ((keep-looking t))


### PR DESCRIPTION
### Match expression cases are not indented.
````pony
match (x, y)
| (None, _) => "none"
| (let s: String, 2) => s + " two"
| (let s: String, 3) => s + " three"
| (let s: String, let u: U32) if u > 14 => s + " other big integer"
| (let s: String, _) => s + " other small integer"
else "something else"
end

match alive
| true =>
  Debug.err("Beep boop!")
  this.forever()
| false =>
  Debug.err("Ugah!")
  None
end
````
