### PR TITLE
Added ffi bare lambdas callback hightlighting

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -323,7 +323,7 @@ by parse-partial-sexp, and should return a face. "
     ("\\(\s\\|\\.\\|->\\|[\[]\\|[\(]\\|=\\)\\($?_?[A-Z][A-Za-z0-9_]*\\)" 2 'font-lock-type-face)
 
     ;; ffi
-     ("@[A-Za-z_][A-Z-a-z0-9_]+" . 'font-lock-builtin-face)
+     ("@[A-Za-z_]*[A-Z-a-z0-9_]*" . 'font-lock-builtin-face)
 
     ;; method references
     ("\\([a-z_]$?[a-z0-9_]?+\\)$?[ \t]?(+" 1 'font-lock-function-name-face)


### PR DESCRIPTION
At moment,  bare lambdas cannot be highlighted correctly:`@{()}`
This PR solves this problem.