### PR TITLE
Improved match indent

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -388,7 +388,7 @@ the current context."
           ((looking-at "^[ \t]*\\(|\\|end\\|else\\|elseif\\|do\\|then\\|until\\)[ \t]*.*$")
            (progn (save-excursion ;;
                     (forward-line -1)
-                    (if (looking-at "^[ \t]*\\(|\\|match\\).*$")
+                    (if (looking-at ".*[ \t]*\\(|\\|match\\).*$")
                         (setq cur-indent (current-indentation))
                       (setq cur-indent (max 0 (- (current-indentation) tab-width)))))))
           (t                            ;


### PR DESCRIPTION
At moment, If there are other characters before the match expression:
```pony
 d =  match name'.lower()
    | "md4" => Digest.md4()
    | "md5" => Digest.md5()
    | "ripemd160" => Digest.ripemd160()
    | "sha1" => Digest.sha1()
    | "sha224" => Digest.sha224()
    | "sha256" => Digest.sha256()
    | "sha384" => Digest.sha384()
    | "sha512" => Digest.sha512()
    | "shake128" => ifdef "openssl_1.1.x" then Digest.shake128() end
    | "shake256" => ifdef "openssl_1.1.x" then Digest.shake256() end
    else
      None
    end
```
After using this PR repair：
```pony
  d =  match name'.lower()
  | "md4" => Digest.md4()
  | "md5" => Digest.md5()
  | "ripemd160" => Digest.ripemd160()
  | "sha1" => Digest.sha1()
  | "sha224" => Digest.sha224()
  | "sha256" => Digest.sha256()
  | "sha384" => Digest.sha384()
  | "sha512" => Digest.sha512()
  | "shake128" => ifdef "openssl_1.1.x" then Digest.shake128() end
  | "shake256" => ifdef "openssl_1.1.x" then Digest.shake256() end
  else
    None
  end
```