### PR TITLE
Fix missing dependencies

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -4,7 +4,7 @@
 ;; Version: 0.5.2
 ;; URL: https://github.com/ponylang/ponylang-mode
 ;; Keywords: languages programming
-;; Package-Requires: ((dash "2.17.0") (hydra "0.15.0") (hl-todo "3.1.2") (yafolding "0.4.1") (rainbow-delimiters "2.1.4") (fill-column-indicator "1.90"))
+;; Package-Requires: ((dash "2.17.0") (hydra "0.15.0") (hl-todo "3.1.2") (yafolding "0.4.1") (yasnippet "0.14.0") (rainbow-delimiters "2.1.4") (fill-column-indicator "1.90"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -67,6 +67,7 @@
 (require 'hl-todo)
 (require 'easymenu)
 (require 'yafolding)
+(require 'yasnippet)
 (require 'whitespace)
 (require 'rainbow-delimiters)
 (require 'fill-column-indicator)


### PR DESCRIPTION
This PR fixes an ancient bug: `yasnippet` is referenced, but no dependencies are added.