### PR TITLE
Fixed default-directory

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -656,7 +656,7 @@ Optional argument PATH ."
 
 (easy-menu-define ponylang-mode-menu ponylang-mode-map ;
   "Menu for Ponylang mode."                            ;
-  '("Ponylang" ;
+  '("Ponylang"                                         ;
      ["Build" ponylang-project-build t]
      ["Run" ponylang-project-run t]     ;
      ["Clean" ponylang-project-clean t]
@@ -857,8 +857,13 @@ Optional argument RETRY ."
           (ponyc-executable (string-trim (shell-command-to-string (concat
                                                                     "readlink -f "
                                                                     ponyc-path))))
-          (packages-path (concat (file-name-directory ponyc-executable)
-                           "../packages") )
+          (packages-path1 (concat (file-name-directory ponyc-executable)
+                            "../packages") )
+          (packages-path2 (concat (file-name-directory ponyc-executable)
+                            "../packages") )
+          (packages-path (if (file-exists-p packages-path1) ;
+                             packages-path1                 ;
+                           packages-path2))
           (ctags-params                 ;
             (concat
               "ctags --languages=-pony --langdef=pony --langmap=pony:.pony "
@@ -874,10 +879,11 @@ Optional argument RETRY ."
               "--regex-pony='/^[ \\t]*type[ \\t]+([a-zA-Z0-9_]+)/\\1/y,type/' "
               "-e -R . " packages-path)))
     (if (file-exists-p packages-path)
-      (progn
+      (let ((oldir default-directory))
         (setq default-directory (ponylang-project-root))
         (shell-command ctags-params)
-        (ponylang-load-tags)))))
+        (ponylang-load-tags)
+        (setq default-directory oldir)))))
 
 (defun ponylang-load-tags
   (&optional


### PR DESCRIPTION
### Brief summary of what the changes does

Reset the `defult-directory` after executing the shell command.

### Checklist

Please confirm with `x`:

- [x] I own the copyright to the submitted changes and indemnify `ponylang-mode` from any copyright claim that might result from my not being the authorized copyright holder.
- [x] I've read [CONTRIBUTING.md](https://github.com/ponylang/ponylang-mode/blob/master/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I have confirmed some of these without doing them
