### PR TITLE
Change melpa version on release

### DIFF
--- a/.ci-scripts/release/update-melpa-version.bash
+++ b/.ci-scripts/release/update-melpa-version.bash
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Updates melpa version as part of release by:
+#
+# - Getting latest changes on master
+# - Versioning for melpa
+# - Pushing updated *.el files back to master
+#
+# Tools required in the environment that runs this:
+#
+# - bash
+# - git
+
+set -o errexit
+
+# Verify ENV is set up correctly
+# We validate all that need to be set in case, in an absolute emergency,
+# we need to run this by hand. Otherwise the GitHub actions environment should
+# provide all of these if properly configured
+if [[ -z "${RELEASE_TOKEN}" ]]; then
+  echo -e "\e[31mA personal access token needs to be set in RELEASE_TOKEN."
+  echo -e "\e[31mIt should not be secrets.GITHUB_TOKEN. It has to be a"
+  echo -e "\e[31mpersonal access token otherwise next steps in the release"
+  echo -e "\e[31mprocess WILL NOT trigger."
+  echo -e "\e[31mPersonal access tokens are in the form:"
+  echo -e "\e[31m     TOKEN"
+  echo -e "\e[31mfor example:"
+  echo -e "\e[31m     1234567890"
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${GITHUB_REF}" ]]; then
+  echo -e "\e[31mThe release tag needs to be set in GITHUB_REF."
+  echo -e "\e[31mThe tag should be in the following GitHub specific form:"
+  echo -e "\e[31m    /refs/tags/release-X.Y.Z"
+  echo -e "\e[31mwhere X.Y.Z is the version we are releasing"
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${GITHUB_REPOSITORY}" ]]; then
+  echo -e "\e[31mName of this repository needs to be set in GITHUB_REPOSITORY."
+  echo -e "\e[31mShould be in the form OWNER/REPO, for example:"
+  echo -e "\e[31m     ponylang/ponyup"
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+# no unset variables allowed from here on out
+# allow above so we can display nice error messages for expected unset variables
+set -o nounset
+
+# Set up .netrc file with GitHub credentials
+git config --global user.name 'Ponylang Main Bot'
+git config --global user.email 'ponylang.main@gmail.com'
+git config --global push.default simple
+
+PUSH_TO="https://${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+# Extract version from tag reference
+# Tag ref version: "refs/tags/release-1.0.0"
+# Version: "1.0.0"
+VERSION="${GITHUB_REF/refs\/tags\/release-/}"
+
+### this doesn't account for master changing commit, assumes we are HEAD
+# or can otherwise push without issue. that shouldl error out without issue.
+# leaving us to restart from a different HEAD commit
+git checkout master
+git pull
+
+# version for melpa
+echo -e "\e[34mUpdating VERSION to ${VERSION}\e[0m"
+sed -i -e "s/;; Version: \(.*\)$/;; Version: ${VERSION}/g" ponylang-mode.el ponylang-test.el
+
+# commit ponylang-mode.el, and ponylang-test.el updates
+echo -e "\e[34mCommiting *.el changes\e[0m"
+git add ponylang-mode.el ponylang-test.el
+git commit -m "${VERSION} release"
+
+# push to release to remote
+echo -e "\e[34mPushing commited changes back to master\e[0m"
+git push "${PUSH_TO}" master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,6 @@ on:
       - \d+.\d+.\d+
 
 jobs:
-  # Artifact building steps go here
-
   trigger-release-announcement:
     name: Trigger release announcement
     runs-on: ubuntu-latest

--- a/.github/workflows/start-a-release.yml
+++ b/.github/workflows/start-a-release.yml
@@ -5,9 +5,22 @@ on:
     tags: release-\d+.\d+.\d+
 
 jobs:
+  update-melpa-version:
+    name: Update .el versions
+    runs-on: ubuntu-latest
+    container:
+      image: ponylang/shared-docker-ci-release:20191107
+    steps:
+      - uses: actions/checkout@v1
+      - name: Start release process
+        run: bash .ci-scripts/release/update-melpa-version.bash
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
   start-a-release:
     name: Start a release
     runs-on: ubuntu-latest
+    needs: [update-melpa-version]
     steps:
       - uses: actions/checkout@v1
       - name: Start


### PR DESCRIPTION
This was broken when I updated to the latest release tools.

The problem? There's one special extra step that is needed as part of
"start a release" where we need to change the version number in the
emacs lisp files.