### PR TITLE
Highlight character literals

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -114,8 +114,9 @@
     ;; \n is a comment ender
     (modify-syntax-entry ?\n ">" table)
 
-    ;; string
+    ;; strings and character literals
     (modify-syntax-entry ?\" "\"" table)
+    (modify-syntax-entry ?\' "\"" table)
 
     ;; Don't treat underscores as whitespace
     (modify-syntax-entry ?_ "w" table) table))


### PR DESCRIPTION
### Highlight character literals

This PR changes the ponylang-mode syntax table to recognize apostrophes as a 'string' delimiter. I ran into an issue where a character literal containing a quotation mark, e.g. `'"'` would throw off syntax highlighting for the rest of the buffer.

Some things:
1. With this change, character literals and string literals appear to use the same font face. I'd be happy to change this, but I'm not exactly sure how.
2. I see that a regex is used to recognize character literals and to use a different font face on them. I'm not noticing any difference when using my ponylang-mode branch locally. Should this be removed?

### Checklist

- [x] I own the copyright to the submitted changes and indemnify `ponylang-mode` from any copyright claim that might result from my not being the authorized copyright holder.
- [x] I've read [CONTRIBUTING.md](https://github.com/ponylang/ponylang-mode/blob/main/CONTRIBUTING.md)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [ ] I have confirmed some of these without doing them
