### PR TITLE
Update actions/checkout from v4.1.1 to v6.0.2

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Announce a release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Announce
         uses: docker://ponylang/release-bot-action:0.5.0
         with:

--- a/.github/workflows/lint-action-workflows.yml
+++ b/.github/workflows/lint-action-workflows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Check workflow files
         uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260311
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint bash, docker, markdown, and yaml
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Lint codebase
         uses: docker://github/super-linter:v3.8.3
         env:
@@ -29,7 +29,7 @@ jobs:
     name: Verify CHANGELOG is valid
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Verify CHANGELOG
         uses: docker://ghcr.io/ponylang/changelog-tool:release
         with:
@@ -56,7 +56,7 @@ jobs:
       uses: emacs-eldev/setup-eldev@v1
 
     - name: Check out the source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
 
     - name: Test the project
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Trigger release announcement
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Trigger
         uses: docker://ponylang/release-bot-action:0.5.0
         with:

--- a/.github/workflows/start-a-release.yml
+++ b/.github/workflows/start-a-release.yml
@@ -14,7 +14,7 @@ jobs:
     container:
       image: ghcr.io/ponylang/shared-docker-ci-emacs-mode-release:20241204
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Start release process
         run: bash .ci-scripts/release/update-melpa-version.bash
         env:
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [update-melpa-version]
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Start
         uses: docker://ponylang/release-bot-action:0.5.0
         with:


### PR DESCRIPTION
Node 20 reaches EOL in April 2026 and GitHub will force Node 24 after June 2, 2026. v6 already uses Node 24 natively.